### PR TITLE
feat: update branding with new logo and green

### DIFF
--- a/src/assets/logo.svg
+++ b/src/assets/logo.svg
@@ -1,0 +1,17 @@
+<svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="200" height="200" rx="100" fill="#8EC4A7" />
+  <circle cx="80" cy="100" r="120" fill="#FFFFFF" />
+  <g fill="#8EC4A7">
+    <path d="M40 108L100 62L160 108H148V148H52V108H40Z" />
+    <rect x="116" y="118" width="20" height="24" rx="3" />
+    <path d="M58 122C58 117.582 61.582 114 66 114H101C105.418 114 109 117.582 109 122V131H118V143H66C61.582 143 58 139.418 58 135V122Z" />
+    <circle cx="89" cy="129" r="7" fill="#FFFFFF" />
+    <circle cx="89" cy="129" r="3.5" />
+    <rect x="130" y="124" width="18" height="8" rx="3" />
+    <rect x="130" y="132" width="8" height="12" rx="3" />
+    <rect x="138" y="138" width="10" height="6" rx="2" />
+    <rect x="64" y="118" width="10" height="14" rx="2" />
+  </g>
+  <text x="34" y="180" font-family="'Poppins', 'Helvetica Neue', Arial, sans-serif" font-size="20" font-weight="600" fill="#8EC4A7">SECUNOLOGIE</text>
+  <text x="60" y="195" font-family="'Poppins', 'Helvetica Neue', Arial, sans-serif" font-size="12" fill="#8EC4A7">Côte d'Ivoire</text>
+</svg>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Shield, Phone, Mail, MapPin, Facebook, Instagram, Linkedin } from 'lucide-react';
+import { Phone, Mail, MapPin, Facebook, Instagram, Linkedin } from 'lucide-react';
+import logo from '../assets/logo.svg';
 
 const Footer: React.FC = () => {
   return (
@@ -8,8 +9,11 @@ const Footer: React.FC = () => {
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           <div className="col-span-1 md:col-span-2">
             <div className="flex items-center mb-4">
-              <Shield className="h-8 w-8 text-blue-400 mr-2" />
-              <span className="text-2xl font-bold">SecunologieCI</span>
+              <img
+                src={logo}
+                alt="Secunologie Côte d'Ivoire"
+                className="h-14 w-auto"
+              />
             </div>
             <p className="text-gray-300 mb-6 max-w-md">
               Votre partenaire de confiance pour toutes vos solutions de sécurité électronique 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { Menu, X, ShoppingCart, User, Search, Shield } from 'lucide-react';
+import { Menu, X, ShoppingCart, User, Search } from 'lucide-react';
+import logo from '../assets/logo.svg';
 import { useCart } from '../contexts/CartContext';
 
 interface HeaderProps {
@@ -32,8 +33,11 @@ const Header: React.FC<HeaderProps> = ({ currentPage, onNavigate }) => {
             }}
             className="flex items-center"
           >
-            <Shield className="h-8 w-8 text-blue-700 mr-2" />
-            <span className="text-2xl font-bold text-gray-900">SecunologieCI</span>
+            <img
+              src={logo}
+              alt="Secunologie Côte d'Ivoire"
+              className="h-10 w-auto"
+            />
           </a>
 
           {/* Desktop Navigation */}

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -173,7 +173,7 @@ const Account: React.FC = () => {
                         </div>
                         <span className={`px-3 py-1 rounded-full text-sm font-medium ${
                           order.status === 'Livré' 
-                            ? 'bg-green-100 text-green-700'
+                            ? 'bg-brand-green-light text-brand-green-dark'
                             : 'bg-orange-100 text-orange-700'
                         }`}>
                           {order.status}
@@ -209,7 +209,7 @@ const Account: React.FC = () => {
                         </div>
                         <span className={`px-3 py-1 rounded-full text-sm font-medium ${
                           quote.status === 'Approuvé' 
-                            ? 'bg-green-100 text-green-700'
+                            ? 'bg-brand-green-light text-brand-green-dark'
                             : 'bg-yellow-100 text-yellow-700'
                         }`}>
                           {quote.status}

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -105,7 +105,7 @@ const Contact: React.FC = () => {
                   <Phone className="h-4 w-4 mr-2" />
                   Appeler maintenant
                 </button>
-                <button className="w-full bg-green-500 hover:bg-green-600 text-white py-3 rounded-lg font-semibold transition-colors flex items-center justify-center">
+                <button className="w-full bg-brand-green hover:bg-brand-green-dark text-white py-3 rounded-lg font-semibold transition-colors flex items-center justify-center">
                   <MessageCircle className="h-4 w-4 mr-2" />
                   Chat WhatsApp
                 </button>
@@ -212,7 +212,7 @@ const Contact: React.FC = () => {
                   Envoyer le message
                 </button>
                 {status === 'success' && (
-                  <p className="text-green-600 text-center">Message envoyé avec succès !</p>
+                  <p className="text-brand-green text-center">Message envoyé avec succès !</p>
                 )}
                 {status === 'error' && (
                   <p className="text-red-600 text-center">Une erreur est survenue. Veuillez réessayer.</p>

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -74,7 +74,7 @@ const Services: React.FC<ServicesProps> = ({ onNavigate }) => {
                 <ul className="space-y-3 mb-6">
                   {service.features.map((feature, featureIndex) => (
                     <li key={featureIndex} className="flex items-center">
-                      <CheckCircle className="h-5 w-5 text-green-500 mr-3 flex-shrink-0" />
+                      <CheckCircle className="h-5 w-5 text-brand-green mr-3 flex-shrink-0" />
                       <span className="text-gray-700">{feature}</span>
                     </li>
                   ))}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,13 @@
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        'brand-green': '#8EC4A7',
+        'brand-green-dark': '#6EAA8C',
+        'brand-green-light': '#E6F2EC',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- add the Secunologie Côte d'Ivoire logo asset and display it in the header and footer
- define a reusable brand green palette in Tailwind and apply it to existing green accents across the app

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68c82dceeb3083289ad1012d73db3070