### PR TITLE
Replace blue palette with brand green styling

### DIFF
--- a/src/components/ChatBot.tsx
+++ b/src/components/ChatBot.tsx
@@ -75,7 +75,7 @@ const ChatBot: React.FC = () => {
       {!isOpen && (
         <button
           onClick={() => setIsOpen(true)}
-          className="fixed bottom-6 right-6 bg-blue-700 text-white p-4 rounded-full shadow-lg hover:bg-blue-800 transition-colors z-50 animate-pulse"
+          className="fixed bottom-6 right-6 bg-brand-green-600 text-white p-4 rounded-full shadow-lg hover:bg-brand-green-700 transition-colors z-50 animate-pulse"
         >
           <MessageCircle className="h-6 w-6" />
         </button>
@@ -85,7 +85,7 @@ const ChatBot: React.FC = () => {
       {isOpen && (
         <div className="fixed bottom-6 right-6 w-80 h-96 bg-white rounded-lg shadow-xl z-50 flex flex-col">
           {/* Header */}
-          <div className="bg-blue-700 text-white p-4 rounded-t-lg flex items-center justify-between">
+          <div className="bg-brand-green-600 text-white p-4 rounded-t-lg flex items-center justify-between">
             <div className="flex items-center">
               <Bot className="h-5 w-5 mr-2" />
               <span className="font-semibold">Assistant SecunologieCI</span>
@@ -110,7 +110,7 @@ const ChatBot: React.FC = () => {
                     className={`max-w-xs px-3 py-2 rounded-lg text-sm ${
                       message.isBot
                         ? 'bg-gray-100 text-gray-800'
-                        : 'bg-blue-700 text-white'
+                        : 'bg-brand-green-600 text-white'
                     }`}
                   >
                     {message.text}
@@ -128,7 +128,7 @@ const ChatBot: React.FC = () => {
                     <button
                       key={index}
                       onClick={() => handleQuickReply(reply)}
-                      className="w-full text-left text-sm px-3 py-2 bg-blue-50 hover:bg-blue-100 rounded text-blue-700 transition-colors"
+                      className="w-full text-left text-sm px-3 py-2 bg-brand-green-50 hover:bg-brand-green-100 rounded text-brand-green-600 transition-colors"
                     >
                       {reply}
                     </button>
@@ -147,11 +147,11 @@ const ChatBot: React.FC = () => {
                 onChange={(e) => setInputText(e.target.value)}
                 onKeyDown={(e) => e.key === 'Enter' && handleSendMessage()}
                 placeholder="Tapez votre message..."
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-green-500 focus:border-transparent"
               />
               <button
                 onClick={handleSendMessage}
-                className="bg-blue-700 text-white px-3 py-2 rounded-lg hover:bg-blue-800 transition-colors"
+                className="bg-brand-green-600 text-white px-3 py-2 rounded-lg hover:bg-brand-green-700 transition-colors"
               >
                 <Send className="h-4 w-4" />
               </button>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -26,7 +26,7 @@ const Footer: React.FC = () => {
                 target="_blank"
                 rel="noreferrer"
               >
-                <Facebook className="h-6 w-6 text-blue-400 hover:text-blue-300 transition-colors" />
+                <Facebook className="h-6 w-6 text-brand-green-400 hover:text-brand-green-300 transition-colors" />
               </a>
               <a
                 href="https://www.instagram.com"
@@ -42,7 +42,7 @@ const Footer: React.FC = () => {
                 target="_blank"
                 rel="noreferrer"
               >
-                <Linkedin className="h-6 w-6 text-blue-400 hover:text-blue-300 transition-colors" />
+                <Linkedin className="h-6 w-6 text-brand-green-400 hover:text-brand-green-300 transition-colors" />
               </a>
             </div>
           </div>
@@ -62,15 +62,15 @@ const Footer: React.FC = () => {
             <h3 className="text-lg font-semibold mb-4">Contact</h3>
             <div className="space-y-3">
               <div className="flex items-center">
-                <Phone className="h-5 w-5 text-blue-400 mr-3" />
+                <Phone className="h-5 w-5 text-brand-green-400 mr-3" />
                 <span className="text-gray-300">+225 07 123 456 78</span>
               </div>
               <div className="flex items-center">
-                <Mail className="h-5 w-5 text-blue-400 mr-3" />
+                <Mail className="h-5 w-5 text-brand-green-400 mr-3" />
                 <span className="text-gray-300">contact@securologieci.com</span>
               </div>
               <div className="flex items-start">
-                <MapPin className="h-5 w-5 text-blue-400 mr-3 mt-1" />
+                <MapPin className="h-5 w-5 text-brand-green-400 mr-3 mt-1" />
                 <span className="text-gray-300">
                   Abidjan, Cocody<br />
                   Riviera Bonoumin

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -53,8 +53,8 @@ const Header: React.FC<HeaderProps> = ({ currentPage, onNavigate }) => {
                   }}
                   className={`px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200 ${
                     currentPage === item.id
-                      ? 'bg-blue-700 text-white'
-                      : 'text-gray-700 hover:bg-blue-50 hover:text-blue-700'
+                      ? 'bg-brand-green-600 text-white'
+                      : 'text-gray-700 hover:bg-brand-green-50 hover:text-brand-green-600'
                   }`}
                 >
                   {item.name}
@@ -65,7 +65,7 @@ const Header: React.FC<HeaderProps> = ({ currentPage, onNavigate }) => {
 
           {/* Actions */}
           <div className="flex items-center space-x-4">
-            <button className="text-gray-700 hover:text-blue-700 transition-colors duration-200">
+            <button className="text-gray-700 hover:text-brand-green-600 transition-colors duration-200">
               <Search className="h-5 w-5" />
             </button>
             
@@ -75,7 +75,7 @@ const Header: React.FC<HeaderProps> = ({ currentPage, onNavigate }) => {
                 e.preventDefault();
                 onNavigate('cart');
               }}
-              className="text-gray-700 hover:text-blue-700 transition-colors duration-200 relative"
+              className="text-gray-700 hover:text-brand-green-600 transition-colors duration-200 relative"
             >
               <ShoppingCart className="h-5 w-5" />
               {state.items.length > 0 && (
@@ -91,7 +91,7 @@ const Header: React.FC<HeaderProps> = ({ currentPage, onNavigate }) => {
                 e.preventDefault();
                 onNavigate('account');
               }}
-              className="text-gray-700 hover:text-blue-700 transition-colors duration-200"
+              className="text-gray-700 hover:text-brand-green-600 transition-colors duration-200"
             >
               <User className="h-5 w-5" />
             </a>
@@ -100,7 +100,7 @@ const Header: React.FC<HeaderProps> = ({ currentPage, onNavigate }) => {
             <div className="md:hidden">
               <button
                 onClick={() => setIsMenuOpen(!isMenuOpen)}
-                className="text-gray-700 hover:text-blue-700 transition-colors duration-200"
+                className="text-gray-700 hover:text-brand-green-600 transition-colors duration-200"
               >
                 {isMenuOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
               </button>
@@ -123,8 +123,8 @@ const Header: React.FC<HeaderProps> = ({ currentPage, onNavigate }) => {
                   }}
                   className={`block w-full text-left px-3 py-2 rounded-md text-base font-medium transition-colors duration-200 ${
                     currentPage === item.id
-                      ? 'bg-blue-700 text-white'
-                      : 'text-gray-700 hover:bg-blue-50 hover:text-blue-700'
+                      ? 'bg-brand-green-600 text-white'
+                      : 'text-gray-700 hover:bg-brand-green-50 hover:text-brand-green-600'
                   }`}
                 >
                   {item.name}

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -30,7 +30,7 @@ const ProductCard: React.FC<ProductCardProps> = ({ product, onViewDetails }) => 
           className="w-full h-48 object-cover group-hover:scale-105 transition-transform duration-300"
         />
         <div className="absolute top-2 left-2">
-          <span className="bg-blue-700 text-white px-2 py-1 rounded text-xs font-medium">
+          <span className="bg-brand-green-600 text-white px-2 py-1 rounded text-xs font-medium">
             {product.brand}
           </span>
         </div>
@@ -70,16 +70,16 @@ const ProductCard: React.FC<ProductCardProps> = ({ product, onViewDetails }) => 
         </p>
         
         <div className="flex items-center justify-between">
-          <span className="text-2xl font-bold text-blue-700">
+          <span className="text-2xl font-bold text-brand-green-700">
             {formatPrice(product.price)}
           </span>
-          
+
           <button
             onClick={handleAddToCart}
             disabled={!product.inStock}
             className={`flex items-center px-4 py-2 rounded-lg font-medium transition-colors ${
               product.inStock
-                ? 'bg-blue-700 text-white hover:bg-blue-800'
+                ? 'bg-brand-green-600 text-white hover:bg-brand-green-700'
                 : 'bg-gray-300 text-gray-500 cursor-not-allowed'
             }`}
           >

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -65,8 +65,8 @@ const About: React.FC = () => {
               }
             ].map((value, index) => (
               <div key={index} className="text-center">
-                <div className="bg-blue-100 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
-                  <value.icon className="h-8 w-8 text-blue-700" />
+                <div className="bg-brand-green-100 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
+                  <value.icon className="h-8 w-8 text-brand-green-600" />
                 </div>
                 <h3 className="text-xl font-semibold text-gray-900 mb-3">{value.title}</h3>
                 <p className="text-gray-600">{value.description}</p>
@@ -84,7 +84,7 @@ const About: React.FC = () => {
             { number: '24/7', label: 'Support technique' }
           ].map((stat, index) => (
             <div key={index} className="text-center bg-white p-6 rounded-lg shadow">
-              <div className="text-3xl font-bold text-blue-700 mb-2">{stat.number}</div>
+              <div className="text-3xl font-bold text-brand-green-700 mb-2">{stat.number}</div>
               <div className="text-gray-600">{stat.label}</div>
             </div>
           ))}
@@ -92,12 +92,12 @@ const About: React.FC = () => {
 
         {/* Mission & Vision */}
         <section className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-16">
-          <div className="bg-blue-700 text-white p-8 rounded-lg">
+          <div className="bg-brand-green-600 text-white p-8 rounded-lg">
             <div className="flex items-center mb-4">
               <Target className="h-8 w-8 mr-3" />
               <h3 className="text-2xl font-bold">Notre mission</h3>
             </div>
-            <p className="text-blue-100">
+            <p className="text-brand-green-100">
               Protéger les biens et les personnes en fournissant des solutions de sécurité 
               électronique innovantes, fiables et adaptées aux besoins spécifiques de chaque client.
             </p>
@@ -154,14 +154,14 @@ const About: React.FC = () => {
           <h2 className="text-3xl font-bold text-gray-900 mb-8">Nous trouver</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
             <div className="flex items-center justify-center">
-              <MapPin className="h-6 w-6 text-blue-700 mr-3" />
+              <MapPin className="h-6 w-6 text-brand-green-600 mr-3" />
               <div>
                 <p className="font-semibold">Adresse</p>
                 <p className="text-gray-600">Abidjan, Cocody - Riviera Bonoumin</p>
               </div>
             </div>
             <div className="flex items-center justify-center">
-              <Clock className="h-6 w-6 text-blue-700 mr-3" />
+              <Clock className="h-6 w-6 text-brand-green-600 mr-3" />
               <div>
                 <p className="font-semibold">Horaires</p>
                 <p className="text-gray-600">Lun-Ven: 8h-18h | Sam: 8h-13h</p>

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -54,8 +54,8 @@ const Account: React.FC = () => {
           <div className="lg:col-span-1">
             <div className="bg-white rounded-lg shadow p-6">
               <div className="text-center mb-6">
-                <div className="w-20 h-20 bg-blue-100 rounded-full mx-auto mb-4 flex items-center justify-center">
-                  <User className="h-10 w-10 text-blue-700" />
+                <div className="w-20 h-20 bg-brand-green-100 rounded-full mx-auto mb-4 flex items-center justify-center">
+                  <User className="h-10 w-10 text-brand-green-600" />
                 </div>
                 <h2 className="text-xl font-bold text-gray-900">Jean Kouassi</h2>
                 <p className="text-gray-600">Client Premium</p>
@@ -70,7 +70,7 @@ const Account: React.FC = () => {
                       onClick={() => setActiveTab(tab.id)}
                       className={`w-full flex items-center px-4 py-3 rounded-lg text-left transition-colors ${
                         activeTab === tab.id
-                          ? 'bg-blue-700 text-white'
+                          ? 'bg-brand-green-600 text-white'
                           : 'text-gray-700 hover:bg-gray-100'
                       }`}
                     >
@@ -102,7 +102,7 @@ const Account: React.FC = () => {
                       <input
                         type="text"
                         defaultValue="Jean"
-                        className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                        className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-green-500 focus:border-transparent"
                       />
                     </div>
                     <div>
@@ -112,7 +112,7 @@ const Account: React.FC = () => {
                       <input
                         type="text"
                         defaultValue="Kouassi"
-                        className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                        className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-green-500 focus:border-transparent"
                       />
                     </div>
                   </div>
@@ -124,7 +124,7 @@ const Account: React.FC = () => {
                     <input
                       type="email"
                       defaultValue="jean.kouassi@email.com"
-                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-green-500 focus:border-transparent"
                     />
                   </div>
                   
@@ -135,7 +135,7 @@ const Account: React.FC = () => {
                     <input
                       type="tel"
                       defaultValue="+225 07 123 456 78"
-                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-green-500 focus:border-transparent"
                     />
                   </div>
                   
@@ -146,11 +146,11 @@ const Account: React.FC = () => {
                     <textarea
                       rows={3}
                       defaultValue="Abidjan, Cocody Riviera"
-                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-green-500 focus:border-transparent"
                     ></textarea>
                   </div>
                   
-                  <button className="bg-blue-700 text-white px-6 py-3 rounded-lg font-semibold hover:bg-blue-800 transition-colors">
+                  <button className="bg-brand-green-600 text-white px-6 py-3 rounded-lg font-semibold hover:bg-brand-green-700 transition-colors">
                     Mettre à jour
                   </button>
                 </form>
@@ -180,10 +180,10 @@ const Account: React.FC = () => {
                         </span>
                       </div>
                       <div className="flex justify-between items-center">
-                        <span className="text-lg font-bold text-blue-700">
+                        <span className="text-lg font-bold text-brand-green-700">
                           {order.total.toLocaleString()} FCFA
                         </span>
-                        <button className="text-blue-700 hover:text-blue-800 font-medium">
+                        <button className="text-brand-green-600 hover:text-brand-green-700 font-medium">
                           Voir détails
                         </button>
                       </div>
@@ -216,15 +216,15 @@ const Account: React.FC = () => {
                         </span>
                       </div>
                       <div className="flex justify-between items-center">
-                        <span className="text-lg font-bold text-blue-700">
+                        <span className="text-lg font-bold text-brand-green-700">
                           {quote.amount.toLocaleString()} FCFA
                         </span>
                         <div className="flex gap-2">
-                          <button className="text-blue-700 hover:text-blue-800 font-medium">
+                          <button className="text-brand-green-600 hover:text-brand-green-700 font-medium">
                             Télécharger
                           </button>
                           {quote.status === 'Approuvé' && (
-                            <button className="bg-blue-700 text-white px-4 py-2 rounded font-medium hover:bg-blue-800">
+                            <button className="bg-brand-green-600 text-white px-4 py-2 rounded font-medium hover:bg-brand-green-700">
                               Valider
                             </button>
                           )}
@@ -247,8 +247,8 @@ const Account: React.FC = () => {
                 <h2 className="text-2xl font-bold text-gray-900 mb-6">Notifications</h2>
                 
                 <div className="space-y-4">
-                  <div className="flex items-start p-4 bg-blue-50 rounded-lg">
-                    <Bell className="h-5 w-5 text-blue-700 mr-3 mt-1" />
+                  <div className="flex items-start p-4 bg-brand-green-50 rounded-lg">
+                    <Bell className="h-5 w-5 text-brand-green-600 mr-3 mt-1" />
                     <div>
                       <h3 className="font-semibold text-gray-900">Commande expédiée</h3>
                       <p className="text-gray-600">Votre commande CMD-2024-002 a été expédiée.</p>

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -36,7 +36,7 @@ const Blog: React.FC = () => {
                   <Calendar className="h-4 w-4 mr-2" />
                   {formatDate(blogPosts[0].date)}
                   <span className="mx-2">•</span>
-                  <span className="bg-blue-100 text-blue-700 px-2 py-1 rounded-full text-xs">
+                  <span className="bg-brand-green-100 text-brand-green-600 px-2 py-1 rounded-full text-xs">
                     {blogPosts[0].category}
                   </span>
                 </div>
@@ -46,7 +46,7 @@ const Blog: React.FC = () => {
                 <p className="text-gray-600 mb-6 text-lg">
                   {blogPosts[0].excerpt}
                 </p>
-                <button className="bg-blue-700 text-white px-6 py-3 rounded-lg font-semibold hover:bg-blue-800 transition-colors flex items-center w-fit">
+                <button className="bg-brand-green-600 text-white px-6 py-3 rounded-lg font-semibold hover:bg-brand-green-700 transition-colors flex items-center w-fit">
                   Lire la suite <ArrowRight className="ml-2 h-4 w-4" />
                 </button>
               </div>
@@ -68,7 +68,7 @@ const Blog: React.FC = () => {
                   <Calendar className="h-4 w-4 mr-2" />
                   {formatDate(post.date)}
                   <span className="mx-2">•</span>
-                  <span className="bg-blue-100 text-blue-700 px-2 py-1 rounded-full text-xs">
+                  <span className="bg-brand-green-100 text-brand-green-600 px-2 py-1 rounded-full text-xs">
                     {post.category}
                   </span>
                 </div>
@@ -78,7 +78,7 @@ const Blog: React.FC = () => {
                 <p className="text-gray-600 mb-4 line-clamp-3">
                   {post.excerpt}
                 </p>
-                <button className="text-blue-700 font-semibold hover:text-blue-800 transition-colors flex items-center">
+                <button className="text-brand-green-600 font-semibold hover:text-brand-green-700 transition-colors flex items-center">
                   Lire la suite <ArrowRight className="ml-2 h-4 w-4" />
                 </button>
               </div>
@@ -93,7 +93,7 @@ const Blog: React.FC = () => {
             {['Guides', 'Actualités', 'Conseils', 'Nouveautés'].map((category, index) => (
               <button
                 key={index}
-                className="bg-gray-100 hover:bg-blue-50 text-gray-700 hover:text-blue-700 px-4 py-3 rounded-lg font-medium transition-colors"
+                className="bg-gray-100 hover:bg-brand-green-50 text-gray-700 hover:text-brand-green-600 px-4 py-3 rounded-lg font-medium transition-colors"
               >
                 {category}
               </button>
@@ -102,9 +102,9 @@ const Blog: React.FC = () => {
         </section>
 
         {/* Newsletter Subscription */}
-        <section className="bg-blue-700 text-white rounded-lg p-8 text-center">
+        <section className="bg-brand-green-600 text-white rounded-lg p-8 text-center">
           <h2 className="text-3xl font-bold mb-4">Restez informé</h2>
-          <p className="text-blue-100 mb-6 text-lg">
+          <p className="text-brand-green-100 mb-6 text-lg">
             Abonnez-vous à notre newsletter pour recevoir nos derniers articles et conseils
           </p>
           <div className="max-w-md mx-auto flex gap-4">

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -30,7 +30,7 @@ const Cart: React.FC<CartProps> = ({ onNavigate }) => {
             <p className="text-gray-600 mb-8">Découvrez nos produits et ajoutez-les à votre panier</p>
             <button
               onClick={() => onNavigate('catalog')}
-              className="bg-blue-700 text-white px-8 py-3 rounded-lg font-semibold hover:bg-blue-800 transition-colors"
+              className="bg-brand-green-600 text-white px-8 py-3 rounded-lg font-semibold hover:bg-brand-green-700 transition-colors"
             >
               Voir le catalogue
             </button>
@@ -60,7 +60,7 @@ const Cart: React.FC<CartProps> = ({ onNavigate }) => {
                   <div className="flex-1">
                     <h3 className="font-semibold text-gray-900">{item.product.name}</h3>
                     <p className="text-sm text-gray-600">{item.product.brand}</p>
-                    <p className="text-lg font-bold text-blue-700">
+                    <p className="text-lg font-bold text-brand-green-700">
                       {formatPrice(item.product.price)}
                     </p>
                   </div>
@@ -108,7 +108,7 @@ const Cart: React.FC<CartProps> = ({ onNavigate }) => {
               <div className="border-t pt-3">
                 <div className="flex justify-between font-bold text-lg">
                   <span>Total</span>
-                  <span className="text-blue-700">{formatPrice(state.total)}</span>
+                  <span className="text-brand-green-700">{formatPrice(state.total)}</span>
                 </div>
               </div>
             </div>
@@ -121,7 +121,7 @@ const Cart: React.FC<CartProps> = ({ onNavigate }) => {
                 Mobile Money
               </button>
               
-              <button className="w-full flex items-center justify-center gap-3 bg-blue-700 text-white py-3 rounded-lg font-semibold hover:bg-blue-800 transition-colors">
+              <button className="w-full flex items-center justify-center gap-3 bg-brand-green-600 text-white py-3 rounded-lg font-semibold hover:bg-brand-green-700 transition-colors">
                 <CreditCard className="h-5 w-5" />
                 Carte bancaire
               </button>

--- a/src/pages/Catalog.tsx
+++ b/src/pages/Catalog.tsx
@@ -58,7 +58,7 @@ const Catalog: React.FC<CatalogProps> = ({ onViewProduct }) => {
               placeholder="Rechercher un produit..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-green-500 focus:border-transparent"
             />
           </div>
           <div className="flex items-center gap-4">
@@ -72,13 +72,13 @@ const Catalog: React.FC<CatalogProps> = ({ onViewProduct }) => {
             <div className="flex border border-gray-300 rounded-lg overflow-hidden">
               <button
                 onClick={() => setViewMode('grid')}
-                className={`p-2 ${viewMode === 'grid' ? 'bg-blue-700 text-white' : 'bg-white text-gray-600'}`}
+                className={`p-2 ${viewMode === 'grid' ? 'bg-brand-green-600 text-white' : 'bg-white text-gray-600'}`}
               >
                 <Grid className="h-4 w-4" />
               </button>
               <button
                 onClick={() => setViewMode('list')}
-                className={`p-2 ${viewMode === 'list' ? 'bg-blue-700 text-white' : 'bg-white text-gray-600'}`}
+                className={`p-2 ${viewMode === 'list' ? 'bg-brand-green-600 text-white' : 'bg-white text-gray-600'}`}
               >
                 <List className="h-4 w-4" />
               </button>
@@ -100,7 +100,7 @@ const Catalog: React.FC<CatalogProps> = ({ onViewProduct }) => {
                 <select
                   value={selectedBrand}
                   onChange={(e) => setSelectedBrand(e.target.value)}
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-brand-green-500 focus:border-transparent"
                 >
                   <option value="">Toutes les marques</option>
                   {brands.map(brand => (
@@ -117,7 +117,7 @@ const Catalog: React.FC<CatalogProps> = ({ onViewProduct }) => {
                 <select
                   value={selectedCategory}
                   onChange={(e) => setSelectedCategory(e.target.value)}
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-brand-green-500 focus:border-transparent"
                 >
                   <option value="">Toutes les catégories</option>
                   {categories.map(category => (
@@ -150,7 +150,7 @@ const Catalog: React.FC<CatalogProps> = ({ onViewProduct }) => {
 
               <button
                 onClick={clearFilters}
-                className="w-full text-blue-700 hover:text-blue-800 font-medium"
+                className="w-full text-brand-green-600 hover:text-brand-green-700 font-medium"
               >
                 Réinitialiser les filtres
               </button>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -54,7 +54,7 @@ const Contact: React.FC = () => {
               
               <div className="space-y-4">
                 <div className="flex items-start">
-                  <Phone className="h-5 w-5 text-blue-700 mr-3 mt-1" />
+                  <Phone className="h-5 w-5 text-brand-green-600 mr-3 mt-1" />
                   <div>
                     <p className="font-semibold text-gray-900">Téléphone</p>
                     <p className="text-gray-600">+225 07 123 456 78</p>
@@ -63,7 +63,7 @@ const Contact: React.FC = () => {
                 </div>
                 
                 <div className="flex items-start">
-                  <Mail className="h-5 w-5 text-blue-700 mr-3 mt-1" />
+                  <Mail className="h-5 w-5 text-brand-green-600 mr-3 mt-1" />
                   <div>
                     <p className="font-semibold text-gray-900">Email</p>
                     <p className="text-gray-600">contact@securologieci.com</p>
@@ -72,7 +72,7 @@ const Contact: React.FC = () => {
                 </div>
                 
                 <div className="flex items-start">
-                  <MapPin className="h-5 w-5 text-blue-700 mr-3 mt-1" />
+                  <MapPin className="h-5 w-5 text-brand-green-600 mr-3 mt-1" />
                   <div>
                     <p className="font-semibold text-gray-900">Adresse</p>
                     <p className="text-gray-600">
@@ -84,7 +84,7 @@ const Contact: React.FC = () => {
                 </div>
                 
                 <div className="flex items-start">
-                  <Clock className="h-5 w-5 text-blue-700 mr-3 mt-1" />
+                  <Clock className="h-5 w-5 text-brand-green-600 mr-3 mt-1" />
                   <div>
                     <p className="font-semibold text-gray-900">Horaires</p>
                     <p className="text-gray-600">
@@ -98,7 +98,7 @@ const Contact: React.FC = () => {
             </div>
 
             {/* Quick Actions */}
-            <div className="bg-blue-700 text-white rounded-lg p-6">
+            <div className="bg-brand-green-600 text-white rounded-lg p-6">
               <h3 className="text-lg font-bold mb-4">Actions rapides</h3>
               <div className="space-y-3">
                 <button className="w-full bg-orange-500 hover:bg-orange-600 text-white py-3 rounded-lg font-semibold transition-colors flex items-center justify-center">
@@ -131,7 +131,7 @@ const Contact: React.FC = () => {
                       required
                       value={formData.name}
                       onChange={handleChange}
-                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-green-500 focus:border-transparent"
                     />
                   </div>
                   
@@ -146,7 +146,7 @@ const Contact: React.FC = () => {
                       required
                       value={formData.email}
                       onChange={handleChange}
-                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-green-500 focus:border-transparent"
                     />
                   </div>
                 </div>
@@ -162,7 +162,7 @@ const Contact: React.FC = () => {
                       name="phone"
                       value={formData.phone}
                       onChange={handleChange}
-                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-green-500 focus:border-transparent"
                     />
                   </div>
                   
@@ -176,7 +176,7 @@ const Contact: React.FC = () => {
                       required
                       value={formData.subject}
                       onChange={handleChange}
-                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-green-500 focus:border-transparent"
                     >
                       <option value="">Choisir un sujet</option>
                       <option value="devis">Demande de devis</option>
@@ -199,14 +199,14 @@ const Contact: React.FC = () => {
                     rows={5}
                     value={formData.message}
                     onChange={handleChange}
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-green-500 focus:border-transparent"
                     placeholder="Décrivez votre projet ou votre question..."
                   ></textarea>
                 </div>
                 
                 <button
                   type="submit"
-                  className="w-full bg-blue-700 text-white py-4 rounded-lg font-semibold hover:bg-blue-800 transition-colors flex items-center justify-center"
+                  className="w-full bg-brand-green-600 text-white py-4 rounded-lg font-semibold hover:bg-brand-green-700 transition-colors flex items-center justify-center"
                 >
                   <Send className="h-5 w-5 mr-2" />
                   Envoyer le message

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -15,7 +15,7 @@ const Home: React.FC<HomeProps> = ({ onNavigate, onViewProduct }) => {
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Hero Section */}
-      <section className="relative bg-gradient-to-r from-blue-900 to-blue-700 text-white overflow-hidden">
+      <section className="relative bg-gradient-to-r from-brand-green-800 to-brand-green-600 text-white overflow-hidden">
         <div className="absolute inset-0 bg-black opacity-20"></div>
         <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
@@ -24,7 +24,7 @@ const Home: React.FC<HomeProps> = ({ onNavigate, onViewProduct }) => {
                 Sécurisez votre monde avec 
                 <span className="text-orange-400"> SecunologieCI</span>
               </h1>
-              <p className="text-xl mb-8 text-blue-100">
+              <p className="text-xl mb-8 text-brand-green-100">
                 Solutions complètes de sécurité électronique : vidéosurveillance, 
                 contrôle d'accès, alarmes et plus encore. Revendeur officiel Hikvision.
               </p>
@@ -35,7 +35,7 @@ const Home: React.FC<HomeProps> = ({ onNavigate, onViewProduct }) => {
                 >
                   Voir le catalogue <ArrowRight className="ml-2 h-5 w-5" />
                 </button>
-                <button className="border-2 border-white text-white px-8 py-4 rounded-lg font-semibold hover:bg-white hover:text-blue-900 transition-colors flex items-center justify-center">
+                <button className="border-2 border-white text-white px-8 py-4 rounded-lg font-semibold hover:bg-white hover:text-brand-green-800 transition-colors flex items-center justify-center">
                   <Play className="mr-2 h-5 w-5" /> Voir la vidéo
                 </button>
               </div>
@@ -62,7 +62,7 @@ const Home: React.FC<HomeProps> = ({ onNavigate, onViewProduct }) => {
               { value: '24/7', label: 'Support technique' },
             ].map((stat, index) => (
               <div key={index} className="text-center">
-                <div className="text-3xl font-bold text-blue-700 mb-2">{stat.value}</div>
+                <div className="text-3xl font-bold text-brand-green-700 mb-2">{stat.value}</div>
                 <div className="text-gray-600">{stat.label}</div>
               </div>
             ))}
@@ -94,9 +94,9 @@ const Home: React.FC<HomeProps> = ({ onNavigate, onViewProduct }) => {
           </div>
           
           <div className="text-center">
-            <button 
+            <button
               onClick={() => onNavigate('catalog')}
-              className="bg-blue-700 text-white px-8 py-3 rounded-lg font-semibold hover:bg-blue-800 transition-colors"
+              className="bg-brand-green-600 text-white px-8 py-3 rounded-lg font-semibold hover:bg-brand-green-700 transition-colors"
             >
               Voir tous les produits
             </button>
@@ -136,8 +136,8 @@ const Home: React.FC<HomeProps> = ({ onNavigate, onViewProduct }) => {
               },
             ].map((service, index) => (
               <div key={index} className="text-center p-6 rounded-lg hover:shadow-lg transition-shadow">
-                <div className="bg-blue-100 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
-                  <service.icon className="h-8 w-8 text-blue-700" />
+                <div className="bg-brand-green-100 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
+                  <service.icon className="h-8 w-8 text-brand-green-600" />
                 </div>
                 <h3 className="text-xl font-semibold mb-3">{service.title}</h3>
                 <p className="text-gray-600">{service.description}</p>
@@ -162,18 +162,18 @@ const Home: React.FC<HomeProps> = ({ onNavigate, onViewProduct }) => {
           <div className="flex justify-center items-center space-x-12 opacity-70">
             <div className="text-4xl font-bold text-red-600">HIKVISION</div>
             <div className="text-4xl font-bold text-red-500">HUAWEI</div>
-            <div className="text-4xl font-bold text-blue-600">EZVIZ</div>
+            <div className="text-4xl font-bold text-brand-green-600">EZVIZ</div>
           </div>
         </div>
       </section>
 
       {/* CTA Section */}
-      <section className="py-16 bg-blue-700 text-white">
+      <section className="py-16 bg-brand-green-600 text-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h2 className="text-3xl font-bold mb-4">
             Prêt à sécuriser votre espace ?
           </h2>
-          <p className="text-xl mb-8 text-blue-100">
+          <p className="text-xl mb-8 text-brand-green-100">
             Contactez nos experts pour un devis gratuit et personnalisé
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
@@ -183,7 +183,7 @@ const Home: React.FC<HomeProps> = ({ onNavigate, onViewProduct }) => {
             >
               Demander un devis
             </button>
-            <button className="border-2 border-white text-white px-8 py-4 rounded-lg font-semibold hover:bg-white hover:text-blue-700 transition-colors">
+            <button className="border-2 border-white text-white px-8 py-4 rounded-lg font-semibold hover:bg-white hover:text-brand-green-600 transition-colors">
               Nous appeler
             </button>
           </div>

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -65,8 +65,8 @@ const Services: React.FC<ServicesProps> = ({ onNavigate }) => {
           {services.map((service, index) => (
             <div key={index} className="bg-white rounded-lg shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300">
               <div className="p-8">
-                <div className="bg-blue-100 w-16 h-16 rounded-full flex items-center justify-center mb-6">
-                  <service.icon className="h-8 w-8 text-blue-700" />
+                <div className="bg-brand-green-100 w-16 h-16 rounded-full flex items-center justify-center mb-6">
+                  <service.icon className="h-8 w-8 text-brand-green-600" />
                 </div>
                 <h3 className="text-2xl font-bold text-gray-900 mb-4">{service.title}</h3>
                 <p className="text-gray-600 mb-6">{service.description}</p>
@@ -81,10 +81,10 @@ const Services: React.FC<ServicesProps> = ({ onNavigate }) => {
                 </ul>
                 
                 <div className="border-t pt-6">
-                  <p className="text-lg font-semibold text-blue-700 mb-4">{service.price}</p>
-                  <button 
+                  <p className="text-lg font-semibold text-brand-green-700 mb-4">{service.price}</p>
+                  <button
                     onClick={() => onNavigate('contact')}
-                    className="w-full bg-blue-700 text-white py-3 rounded-lg font-semibold hover:bg-blue-800 transition-colors"
+                    className="w-full bg-brand-green-600 text-white py-3 rounded-lg font-semibold hover:bg-brand-green-700 transition-colors"
                   >
                     Demander un devis
                   </button>
@@ -124,7 +124,7 @@ const Services: React.FC<ServicesProps> = ({ onNavigate }) => {
               }
             ].map((process, index) => (
               <div key={index} className="text-center">
-                <div className="bg-blue-700 text-white w-12 h-12 rounded-full flex items-center justify-center text-xl font-bold mx-auto mb-4">
+                <div className="bg-brand-green-600 text-white w-12 h-12 rounded-full flex items-center justify-center text-xl font-bold mx-auto mb-4">
                   {process.step}
                 </div>
                 <h3 className="font-semibold text-gray-900 mb-2">{process.title}</h3>
@@ -135,7 +135,7 @@ const Services: React.FC<ServicesProps> = ({ onNavigate }) => {
         </section>
 
         {/* Guarantees Section */}
-        <section className="bg-blue-700 text-white rounded-lg p-8 mb-16">
+        <section className="bg-brand-green-600 text-white rounded-lg p-8 mb-16">
           <h2 className="text-3xl font-bold text-center mb-12">Nos garanties</h2>
           
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
@@ -157,11 +157,11 @@ const Services: React.FC<ServicesProps> = ({ onNavigate }) => {
               }
             ].map((guarantee, index) => (
               <div key={index} className="text-center">
-                <div className="bg-blue-600 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
+                <div className="bg-brand-green-500 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
                   <guarantee.icon className="h-8 w-8" />
                 </div>
                 <h3 className="text-xl font-semibold mb-3">{guarantee.title}</h3>
-                <p className="text-blue-100">{guarantee.description}</p>
+                <p className="text-brand-green-100">{guarantee.description}</p>
               </div>
             ))}
           </div>
@@ -176,13 +176,13 @@ const Services: React.FC<ServicesProps> = ({ onNavigate }) => {
             Contactez nos experts pour discuter de votre projet
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <button 
+            <button
               onClick={() => onNavigate('contact')}
-              className="bg-blue-700 text-white px-8 py-4 rounded-lg font-semibold hover:bg-blue-800 transition-colors"
+              className="bg-brand-green-600 text-white px-8 py-4 rounded-lg font-semibold hover:bg-brand-green-700 transition-colors"
             >
               Nous contacter
             </button>
-            <button className="border-2 border-blue-700 text-blue-700 px-8 py-4 rounded-lg font-semibold hover:bg-blue-700 hover:text-white transition-colors">
+            <button className="border-2 border-brand-green-600 text-brand-green-600 px-8 py-4 rounded-lg font-semibold hover:bg-brand-green-600 hover:text-white transition-colors">
               Télécharger notre brochure
             </button>
           </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,9 +4,21 @@ export default {
   theme: {
     extend: {
       colors: {
-        'brand-green': '#8EC4A7',
-        'brand-green-dark': '#6EAA8C',
-        'brand-green-light': '#E6F2EC',
+        'brand-green': {
+          50: '#F3F9F6',
+          100: '#E6F2EC',
+          200: '#D1E6DB',
+          300: '#B7DAC8',
+          400: '#9CCDB4',
+          500: '#8EC4A7',
+          600: '#6EAA8C',
+          700: '#4F8F73',
+          800: '#356D57',
+          900: '#255844',
+          DEFAULT: '#8EC4A7',
+          light: '#E6F2EC',
+          dark: '#4F8F73',
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary
- define a brand green color scale in Tailwind so the UI can use consistent shades of the logo green
- swap former blue backgrounds, text, and focus states for the new brand green styling across shared components and pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68c83774bfe88328be33911c7f57f47a