### PR TITLE
Use official logos for partner section

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -159,10 +159,22 @@ const Home: React.FC<HomeProps> = ({ onNavigate, onViewProduct }) => {
             </p>
           </div>
           
-          <div className="flex justify-center items-center space-x-12 opacity-70">
-            <div className="text-4xl font-bold text-red-600">HIKVISION</div>
-            <div className="text-4xl font-bold text-red-500">HUAWEI</div>
-            <div className="text-4xl font-bold text-brand-green-600">EZVIZ</div>
+          <div className="flex flex-wrap justify-center items-center gap-12">
+            <img
+              src="https://upload.wikimedia.org/wikipedia/commons/2/2f/Hikvision_logo.svg"
+              alt="Logo Hikvision"
+              className="h-12 object-contain"
+            />
+            <img
+              src="https://upload.wikimedia.org/wikipedia/commons/1/1b/Huawei_logo.svg"
+              alt="Logo Huawei"
+              className="h-12 object-contain"
+            />
+            <img
+              src="https://upload.wikimedia.org/wikipedia/commons/2/2c/Ezviz_logo.svg"
+              alt="Logo EZVIZ"
+              className="h-12 object-contain"
+            />
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- replace the partner name placeholders with the official Hikvision, Huawei, and EZVIZ logos on the home page
- adjust the layout of the partner section to accommodate the logo images while keeping the spacing consistent

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_b_68c8625fdab48328b968ec21a3d87aff