### PR TITLE
Improve API base URL handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Cette application Vite + React fournit l'interface de SecunologieCI. Elle dispos
 
    Vite est configuré pour proxyfier automatiquement les appels `/api` vers `http://localhost:5000`.
 
+   Lors d'un déploiement, vous pouvez définir `VITE_API_BASE_URL` pour pointer vers l'origine de votre API (exemple : `https://mon-backend.example.com`).
+   Le front tentera d'abord cet URL tel quel, puis réessaiera automatiquement avec le suffixe `/api` si nécessaire avant de revenir sur la valeur relative `/api`.
+
 ## Tests
 
 ```bash


### PR DESCRIPTION
## Summary
- add resilient API client that retries with `/api` prefix when the configured base URL fails
- document how the front-end resolves `VITE_API_BASE_URL` when deploying the app

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d65b32ddf883288125defd12275207